### PR TITLE
Include the channel name in audit log messages.

### DIFF
--- a/src/core/activity-registerer.ts
+++ b/src/core/activity-registerer.ts
@@ -18,30 +18,26 @@ export default class ActivityRegisterer
             && this.isGuildSetUp(guild))
         {
             guild.users.set(member.id, new Date())
-            await this.markActiveIfNotIgnored(guild, member, true)
+            await this.markActiveIfNotIgnored(guild, member)
             await guild.save()
         }
     }
 
-    private async markActiveIfNotIgnored(guild: Guild, member: BotGuildMember, isActive: boolean)
+    private async markActiveIfNotIgnored(guild: Guild, member: BotGuildMember)
     {
-        const addRole = isActive ? guild.activeRoleId : guild.inactiveRoleId
-        const removeRole = isActive ? guild.inactiveRoleId : guild.activeRoleId
-
         try
         {
             if (this.isMemberIgnored(guild, member))
                 return
 
-            if (addRole && addRole !== "disabled")
-                await member.addRole(addRole);
+            await member.addRole(guild.activeRoleId);
 
-            if (removeRole && removeRole !== "disabled")
-                await member.removeRole(removeRole)
+            if (guild.inactiveRoleId && guild.inactiveRoleId !== "disabled")
+                await member.removeRole(guild.inactiveRoleId)
         }
         catch (e)
         {
-            Logger.debugLogError(`Error marking user ${member.username} ${isActive ? "active" : "inactive"} in guild ${guild.name}.`, e)
+            Logger.debugLogError(`Error marking user ${member.username} active in guild ${guild.name}.`, e)
         }
     }
 


### PR DESCRIPTION
- Removed the `isActive` parameter from `ActivityRegisterer::markActiveIfNotIgnored` (this method now has checks similar to [InactivityManager::manageInactiveUsersInGuild](https://github.com/benji7425/discord-activity-monitor/blob/master/src/core/inactivity-manager.ts#L43-L45)).
- Added the `channelName` parameter to `ActivityRegisterer::registerActivity` and `markActiveIfNotIgnored`.
- Added a message to `member.djs.addRole` to display the channel name Discord's audit log

To do this I had to use the DiscordJS `voiceStateUpdate` event instead of the Disharmony `onVoiceStateUpdate` as it does not pass the [newUser](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-voiceStateUpdate). This is needed as `oldMember.voiceChannel` would be null when a user joins a voice channel and `newMember.voiceChannel` is null when a user leaves a voice channel.

Partially implements #14 